### PR TITLE
Report timestamps up to millisecond precision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 regions.xml.gz
 srsglass.xlsx
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ A command-line utility for generating NationStates region update timesheets
 Usage: srsglass [OPTIONS] --nation <USER_NATION>
 
 Options:
-  -n, --nation <USER_NATION>  The name of your nation, to identify you to NationStates
-  -o, --outfile <OUTFILE>     Name of the output file [default: srsglass.xlsx]
-      --major <MAJOR_LENGTH>  Length of major update, in seconds [default: 5350]
-      --minor <MINOR_LENGTH>  Length of minor update, in seconds [default: 3550]
-  -d, --dump                  Use the current data dump instead of downloading
-  -p, --path <DUMP_PATH>      Path to the data dump [default: regions.xml.gz]
-  -h, --help                  Print help
-  -V, --version               Print version
+  -n, --nation <USER_NATION>   The name of your nation, to identify you to NationStates
+  -o, --outfile <OUTFILE>      Name of the output file [default: srsglass.xlsx]
+      --major <MAJOR_LENGTH>   Length of major update, in seconds [default: 5350]
+      --minor <MINOR_LENGTH>   Length of minor update, in seconds [default: 3550]
+  -d, --dump                   Use the current data dump instead of downloading
+  -p, --path <DUMP_PATH>       Path to the data dump [default: regions.xml.gz]
+      --precision <PRECISION>  The number of milliseconds to use in timestamps [default: 0]
+  -h, --help                   Print help
+  -V, --version                Print version
 ```
 
 ## Performance

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ struct Cli {
     /// Path to the data dump
     #[arg(short = 'p', long = "path", default_value = "regions.xml.gz")]
     dump_path: String,
+
+    /// The number of milliseconds to use in timestamps
+    #[arg(long = "precision", default_value_t = 0)]
+    precision: i32,
 }
 
 fn main() -> Result<()> {
@@ -82,15 +86,10 @@ fn main() -> Result<()> {
         args.minor_length,
         get_governorless_regions(&agent)?,
         get_passwordless_regions(&agent)?,
+        args.precision,
     )?;
 
     println!("Saved timesheet to {}", args.outfile);
-
-    // let governorless =
-    // let passwordless = get_passwordless_regions(&agent)?;
-
-    // dbg!(governorless);
-    // dbg!(passwordless);
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds support for reporting estimated update times up to the millisecond, along with a `--precision` flag to set the number of milliseconds to display (since Excel's built-in "Increase Decimal" and "Decrease Decimal" options don't seem to work on datetimes).