### PR TITLE
Extract date of dump 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "srsglass"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +124,42 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
 
 [[package]]
 name = "clap"
@@ -151,6 +208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +255,29 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "idna"
@@ -246,16 +332,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -283,6 +425,21 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
@@ -382,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +555,8 @@ name = "srsglass"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "chrono-tz",
  "clap",
  "flate2",
  "quick-xml",
@@ -587,12 +752,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -601,13 +775,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -617,10 +806,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -629,10 +830,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -641,16 +854,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +124,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "clap"
@@ -151,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +233,29 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "idna"
@@ -243,6 +307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -389,9 +462,10 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "srsglass"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "flate2",
  "quick-xml",
@@ -587,12 +661,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -601,13 +684,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -617,10 +715,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -629,10 +739,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -641,16 +763,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,21 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,12 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,20 +103,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "clap"
@@ -186,12 +151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,29 +192,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "idna"
@@ -307,15 +243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -462,10 +389,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "srsglass"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "flate2",
  "quick-xml",
@@ -661,21 +587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.0",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -684,28 +601,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -715,22 +617,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -739,22 +629,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -763,34 +641,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srsglass"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+chrono = "0.4.31"
+chrono-tz = "0.8.5"
 clap = { version = "4.4.4", features = ["derive"] }
 flate2 = "1.0.27"
 quick-xml = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "srsglass"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-chrono = "0.4.31"
 clap = { version = "4.4.4", features = ["derive"] }
 flate2 = "1.0.27"
 quick-xml = "0.30.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "srsglass"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+chrono = "0.4.31"
 clap = { version = "4.4.4", features = ["derive"] }
 flate2 = "1.0.27"
 quick-xml = "0.30.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,345 +1,412 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use flate2::read::GzDecoder;
 use quick_xml::{events::Event, Reader};
 use rust_xlsxwriter::{Color, ExcelDateTime, Format, Workbook};
-use std::{fs::File, io::BufReader, path::Path, time::SystemTime};
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+    time::SystemTime,
+};
 use ureq::Agent;
 
 #[derive(Default, Debug)]
 pub struct Region {
     pub name: Option<String>,
-    factbook: Option<String>,
+    pub factbook: Option<String>,
     pub population: Option<i32>,
-    // delegate: Option<String>,
     pub delegate_votes: Option<i32>,
     pub delegate_exec: Option<bool>,
-    // frontier: Option<bool>,
-    // governor: Option<String>,
     pub last_major: Option<i64>,
     pub last_minor: Option<i64>,
     pub nations_before: Option<i32>,
     pub embassies: Vec<String>,
 }
 
-pub fn download_dump(agent: &Agent, output_file: impl AsRef<Path>) -> Result<()> {
-    let mut res = agent
-        .get("https://www.nationstates.net/pages/regions.xml.gz")
-        .call()?
-        .into_reader();
-
-    std::io::copy(&mut res, &mut File::create(output_file)?)?;
-
-    Ok(())
+pub struct Dump {
+    pub regions: Vec<Region>,
+    pub governorless: Vec<String>,
+    pub passwordless: Vec<String>,
 }
 
-pub fn parse_dump(dump_path: impl AsRef<Path>) -> Result<Vec<Region>> {
-    let gz = BufReader::new(GzDecoder::new(File::open(dump_path)?));
-    let mut reader = Reader::from_reader(gz);
-    reader.trim_text(true);
-
-    let mut buf = Vec::new();
-
-    let mut current_tag = None;
-    let mut current_region = Region::default();
-
-    let mut current_population = 0;
-
-    let mut regions: Vec<Region> = Vec::new();
-
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(e)) => {
-                current_tag = Some(e.to_owned());
-            }
-            Ok(Event::End(e)) => {
-                if let Some(current_tag_name) = current_tag.as_deref() {
-                    if e.name().as_ref() == current_tag_name {
-                        current_tag = None;
-                    }
-                }
-
-                if e.name().as_ref() == b"REGION" {
-                    current_region.nations_before = Some(current_population);
-
-                    if let Some(population) = current_region.population {
-                        current_population += population;
-                    }
-
-                    regions.push(current_region);
-
-                    current_region = Region::default();
-                }
-            }
-            Ok(Event::Text(e)) => {
-                if let Some(tag) = current_tag.as_ref() {
-                    match tag.name().as_ref() {
-                        b"NAME" => current_region.name = Some(e.unescape()?.to_string()),
-                        b"NUMNATIONS" => current_region.population = Some(e.unescape()?.parse()?),
-                        b"DELEGATEVOTES" => {
-                            current_region.delegate_votes = Some(e.unescape()?.parse()?);
-                        }
-                        b"DELEGATEAUTH" => {
-                            current_region.delegate_exec = Some(e.unescape()?.contains('X'));
-                        }
-                        b"LASTMAJORUPDATE" => {
-                            current_region.last_major = Some(e.unescape()?.parse()?);
-                        }
-                        b"LASTMINORUPDATE" => {
-                            current_region.last_minor = Some(e.unescape()?.parse()?);
-                        }
-                        b"EMBASSY" => current_region.embassies.push(e.unescape()?.to_string()),
-                        _ => (),
-                    }
-                }
-            }
-            Ok(Event::CData(e)) => {
-                if let Some(b"FACTBOOK") = current_tag.as_deref() {
-                    current_region.factbook = Some(e.escape()?.unescape()?.trim().to_string());
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-
-        buf.clear();
-    }
-
-    Ok(regions)
+pub struct Client {
+    agent: Agent,
 }
 
-pub fn save_to_excel(
-    regions: impl Iterator<Item = Region>,
-    total_population: i32,
-    output_file: impl AsRef<Path>,
-    major_length: i32,
-    minor_length: i32,
-    governorless: Vec<String>,
-    passwordless: Vec<String>,
-    timestamp_precision: i32,
-) -> Result<()> {
-    let mut workbook = Workbook::new();
-    let worksheet = workbook.add_worksheet();
-
-    worksheet.set_column_width(0, 45)?;
-
-    let red_fill = Format::new().set_background_color(Color::Red);
-    let yellow_fill = Format::new().set_background_color(Color::Yellow);
-    let green_fill = Format::new().set_background_color(Color::Lime);
-
-    worksheet.write_row(
-        0,
-        0,
-        [
-            "Region",
-            "Link",
-            "Population",
-            "Total Nations",
-            "Minor",
-            "Major",
-            "Del. Votes",
-            "Del. Endos",
-            "Embassies",
-            "WFE",
-        ],
-    )?;
-
-    // excel only suppots up to 3 milliseconds of precision
-    if !(0..=3).contains(&timestamp_precision) {
-        return Err(anyhow::anyhow!(
-            "timestamp_precision must be between 0 and 3"
-        ));
-    }
-
-    let duration_string = match timestamp_precision {
-        0 => "[h]:mm:ss",
-        1 => "[h]:mm:ss.0",
-        2 => "[h]:mm:ss.00",
-        3 => "[h]:mm:ss.000",
-        _ => unreachable!(),
-    };
-
-    let duration_format = Format::new().set_num_format(duration_string);
-    worksheet.set_column_format(4, &duration_format)?;
-    worksheet.set_column_format(5, &duration_format)?;
-
-    worksheet.write_column(
-        0,
-        11,
-        [
-            "World Data",
-            "Nations",
-            "Major Length",
-            "Secs/Nation",
-            "Nations/Sec",
-            "Minor Length",
-            "Secs/Nation",
-            "Nations/Sec",
-            "",
-            "Srsglass Version",
-            "Date Generated",
-        ],
-    )?;
-
-    worksheet.write_number(1, 12, total_population)?;
-    worksheet.write_number(2, 12, major_length)?;
-    worksheet.write_number(3, 12, major_length as f64 / total_population as f64)?;
-    worksheet.write_number(4, 12, total_population as f64 / major_length as f64)?;
-    worksheet.write_number(5, 12, minor_length)?;
-    worksheet.write_number(6, 12, minor_length as f64 / total_population as f64)?;
-    worksheet.write_number(7, 12, total_population as f64 / minor_length as f64)?;
-    worksheet.write_string(9, 12, env!("CARGO_PKG_VERSION"))?;
-
-    // set column width to fit date
-    worksheet.set_column_width(12, 10)?;
-
-    // set column widths to fit timestamp
-    worksheet.set_column_width(4, 10)?;
-    worksheet.set_column_width(5, 10)?;
-
-    worksheet.write_datetime_with_format(
-        10,
-        12,
-        &ExcelDateTime::from_timestamp(
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)?
-                .as_secs()
-                .try_into()?,
-        )?,
-        &Format::new().set_num_format("yyyy-mm-dd;@"),
-    )?;
-
-    let mut row_index = 1;
-
-    for region in regions {
-        let Region {
-            name: Some(name),
-            population: Some(population),
-            delegate_votes: Some(delegate_votes),
-            factbook: Some(mut factbook),
-            nations_before: Some(nations_before),
-            delegate_exec: Some(delegate_exec),
-            embassies,
-            ..
-        } = region
-        else {
-            continue;
-        };
-
-        let is_governorless = governorless.iter().any(|r| r == &name);
-        let is_passwordless = passwordless.iter().any(|r| r == &name);
-
-        let format = if is_governorless && is_passwordless {
-            Some(&green_fill)
-        } else if !is_governorless && delegate_exec && is_passwordless {
-            Some(&yellow_fill)
-        } else if !is_passwordless {
-            Some(&red_fill)
-        } else {
-            None
-        };
-
-        let link = format!(
-            "https://www.nationstates.net/region={}",
-            name.to_lowercase().replace(' ', "_")
+impl Client {
+    pub fn new(user_nation: &str) -> Self {
+        let user_agent = format!(
+            "{}/{} (by:Esfalsa, usedBy:{})",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            user_nation
         );
 
-        if let Some(format) = format {
-            worksheet.write_string_with_format(row_index, 0, &name, format)?;
-            worksheet.write_url_with_format(row_index, 1, link.as_str(), format)?;
-        } else {
-            worksheet.write_string(row_index, 0, &name)?;
-            worksheet.write_url(row_index, 1, link.as_str())?;
-        }
+        let agent = ureq::AgentBuilder::new().user_agent(&user_agent).build();
 
-        worksheet.write_number(row_index, 2, population)?;
-
-        worksheet.write_number(row_index, 3, nations_before)?;
-
-        let progress = nations_before as f64 / total_population as f64;
-
-        let minor_duration = progress * minor_length as f64;
-        let minor_h = (minor_duration / 3600.0).floor() as u16;
-        let minor_m = ((minor_duration / 60.0) % 60.0).floor() as u8;
-        let minor_s = (minor_duration % 60.0).floor() as u8;
-        let minor_ms = (minor_duration.fract() * 1000.0).round().clamp(0.0, 999.0) as u16;
-
-        worksheet.write_datetime(
-            row_index,
-            4,
-            &ExcelDateTime::from_hms_milli(minor_h, minor_m, minor_s, minor_ms)?,
-        )?;
-
-        let major_duration = progress * major_length as f64;
-        let major_h = (major_duration / 3600.0).floor() as u16;
-        let major_m = ((major_duration / 60.0) % 60.0).floor() as u8;
-        let major_s = (major_duration % 60.0).floor() as u8;
-        let major_ms = (major_duration.fract() * 1000.0).round().clamp(0.0, 999.0) as u16;
-
-        worksheet.write_datetime(
-            row_index,
-            5,
-            &ExcelDateTime::from_hms_milli(major_h, major_m, major_s, major_ms)?,
-        )?;
-
-        worksheet.write_number(row_index, 6, delegate_votes)?;
-
-        if delegate_votes == 0 {
-            worksheet.write_number_with_format(row_index, 7, delegate_votes, &red_fill)?;
-        } else {
-            worksheet.write_number(row_index, 7, delegate_votes - 1)?;
-        }
-
-        // maximum length of cell contents in Excel is 32,767 characters
-        // https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
-        let mut embassy_list = embassies.join(",");
-        embassy_list.truncate(32767);
-        worksheet.write_string(row_index, 8, embassy_list)?;
-
-        factbook.truncate(32767);
-        worksheet.write_string(row_index, 9, factbook)?;
-
-        row_index += 1;
+        Self { agent }
     }
 
-    workbook.save(output_file)?;
+    pub fn get_dump(&self) -> Result<Dump> {
+        let regions = self.get_regions()?;
+        let goverorless = self.get_governorless_regions()?;
+        let passwordless = self.get_passwordless_regions()?;
 
-    Ok(())
-}
-
-fn get_regions(agent: &Agent, url: &str) -> Result<Vec<String>> {
-    let body = agent.get(url).call()?.into_string()?;
-
-    let mut reader = Reader::from_str(&body);
-
-    let mut collecting = false;
-    let mut regions: Vec<String> = Vec::new();
-
-    loop {
-        match reader.read_event()? {
-            Event::Start(e) if e.name().as_ref() == b"REGIONS" => {
-                collecting = true;
-            }
-            Event::End(e) if e.name().as_ref() == b"REGIONS" => {
-                collecting = false;
-            }
-            Event::Text(e) if collecting => {
-                regions = e.unescape()?.split(',').map(|s| s.to_string()).collect();
-            }
-            Event::Eof => break,
-            _ => (),
-        }
+        Ok(Dump {
+            regions,
+            governorless: goverorless,
+            passwordless,
+        })
     }
 
-    Ok(regions)
+    pub fn get_dump_from_file<P: AsRef<Path>>(&self, dump_path: P) -> Result<Dump> {
+        let regions = self.get_regions_from_file(dump_path)?;
+        let goverorless = self.get_governorless_regions()?;
+        let passwordless = self.get_passwordless_regions()?;
+
+        Ok(Dump {
+            regions,
+            governorless: goverorless,
+            passwordless,
+        })
+    }
+
+    pub fn get_regions(&self) -> Result<Vec<Region>> {
+        let response = self
+            .agent
+            .get("https://www.nationstates.net/pages/regions.xml.gz")
+            .call()?;
+        self.parse_dump(response.into_reader())
+    }
+
+    pub fn get_regions_from_file<P: AsRef<Path>>(&self, dump_path: P) -> Result<Vec<Region>> {
+        self.parse_dump(File::open(dump_path)?)
+    }
+
+    pub fn get_governorless_regions(&self) -> Result<Vec<String>> {
+        let url = "https://www.nationstates.net/cgi-bin/api.cgi?q=regionsbytag;tags=governorless";
+        self.parse_api_response(url)
+    }
+
+    pub fn get_passwordless_regions(&self) -> Result<Vec<String>> {
+        let url = "https://www.nationstates.net/cgi-bin/api.cgi?q=regionsbytag;tags=-password";
+        self.parse_api_response(url)
+    }
+
+    fn parse_dump(&self, dump: impl Read) -> Result<Vec<Region>> {
+        let dump = BufReader::new(GzDecoder::new(dump));
+        let mut reader = Reader::from_reader(dump);
+
+        let mut buf = Vec::new();
+
+        let mut current_tag = None;
+        let mut current_region = Region::default();
+
+        let mut current_population = 0;
+
+        let mut regions: Vec<Region> = Vec::new();
+
+        loop {
+            match reader.read_event_into(&mut buf)? {
+                Event::Start(e) => {
+                    current_tag = Some(e.to_owned());
+                }
+                Event::End(e) => {
+                    if let Some(current_tag_name) = current_tag.as_deref() {
+                        if e.name().as_ref() == current_tag_name {
+                            current_tag = None;
+                        }
+                    }
+
+                    if e.name().as_ref() == b"REGION" {
+                        current_region.nations_before = Some(current_population);
+
+                        if let Some(population) = current_region.population {
+                            current_population += population;
+                        }
+
+                        regions.push(current_region);
+
+                        current_region = Region::default();
+                    }
+                }
+                Event::Text(e) => {
+                    if let Some(tag) = current_tag.as_ref() {
+                        match tag.name().as_ref() {
+                            b"NAME" => current_region.name = Some(e.unescape()?.to_string()),
+                            b"NUMNATIONS" => {
+                                current_region.population = Some(e.unescape()?.parse()?)
+                            }
+                            b"DELEGATEVOTES" => {
+                                current_region.delegate_votes = Some(e.unescape()?.parse()?);
+                            }
+                            b"DELEGATEAUTH" => {
+                                current_region.delegate_exec = Some(e.unescape()?.contains('X'));
+                            }
+                            b"LASTMAJORUPDATE" => {
+                                current_region.last_major = Some(e.unescape()?.parse()?);
+                            }
+                            b"LASTMINORUPDATE" => {
+                                current_region.last_minor = Some(e.unescape()?.parse()?);
+                            }
+                            b"EMBASSY" => current_region.embassies.push(e.unescape()?.to_string()),
+                            _ => (),
+                        }
+                    }
+                }
+                Event::CData(e) => {
+                    if let Some(b"FACTBOOK") = current_tag.as_deref() {
+                        current_region.factbook = Some(e.escape()?.unescape()?.trim().to_string());
+                    }
+                }
+                Event::Eof => break,
+                _ => (),
+            }
+
+            buf.clear();
+        }
+
+        Ok(regions)
+    }
+
+    fn parse_api_response(&self, url: &str) -> Result<Vec<String>> {
+        let body = self.agent.get(url).call()?.into_string()?;
+
+        let mut reader = Reader::from_str(&body);
+
+        let mut collecting = false;
+        let mut regions: Vec<String> = Vec::new();
+
+        loop {
+            match reader.read_event()? {
+                Event::Start(e) if e.name().as_ref() == b"REGIONS" => {
+                    collecting = true;
+                }
+                Event::End(e) if e.name().as_ref() == b"REGIONS" => {
+                    collecting = false;
+                }
+                Event::Text(e) if collecting => {
+                    regions = e.unescape()?.split(',').map(|s| s.to_string()).collect();
+                }
+                Event::Eof => break,
+                _ => (),
+            }
+        }
+
+        Ok(regions)
+    }
 }
 
-pub fn get_governorless_regions(agent: &Agent) -> Result<Vec<String>> {
-    let url = "https://www.nationstates.net/cgi-bin/api.cgi?q=regionsbytag;tags=governorless";
-    get_regions(agent, url)
-}
+impl Dump {
+    pub fn to_excel(
+        self,
+        output_file: impl AsRef<Path>,
+        major_length: i32,
+        minor_length: i32,
+        timestamp_precision: i32,
+    ) -> Result<()> {
+        let Dump {
+            regions,
+            governorless,
+            passwordless,
+        } = self;
 
-pub fn get_passwordless_regions(agent: &Agent) -> Result<Vec<String>> {
-    let url = "https://www.nationstates.net/cgi-bin/api.cgi?q=regionsbytag;tags=-password";
-    get_regions(agent, url)
+        let total_population = regions
+            .last()
+            .and_then(|region| {
+                region
+                    .population
+                    .zip(region.nations_before)
+                    .map(|(population, nations_before)| population + nations_before)
+            })
+            .ok_or(anyhow!("Could not find total world population"))?;
+
+        let mut workbook = Workbook::new();
+        let worksheet = workbook.add_worksheet();
+
+        worksheet.set_column_width(0, 45)?;
+
+        let red_fill = Format::new().set_background_color(Color::Red);
+        let yellow_fill = Format::new().set_background_color(Color::Yellow);
+        let green_fill = Format::new().set_background_color(Color::Lime);
+
+        worksheet.write_row(
+            0,
+            0,
+            [
+                "Region",
+                "Link",
+                "Population",
+                "Total Nations",
+                "Minor",
+                "Major",
+                "Del. Votes",
+                "Del. Endos",
+                "Embassies",
+                "WFE",
+            ],
+        )?;
+
+        // excel only suppots up to 3 milliseconds of precision
+        if !(0..=3).contains(&timestamp_precision) {
+            return Err(anyhow::anyhow!(
+                "timestamp_precision must be between 0 and 3"
+            ));
+        }
+
+        let duration_string = match timestamp_precision {
+            0 => "[h]:mm:ss",
+            1 => "[h]:mm:ss.0",
+            2 => "[h]:mm:ss.00",
+            3 => "[h]:mm:ss.000",
+            _ => unreachable!(),
+        };
+
+        let duration_format = Format::new().set_num_format(duration_string);
+        worksheet.set_column_format(4, &duration_format)?;
+        worksheet.set_column_format(5, &duration_format)?;
+
+        worksheet.write_column(
+            0,
+            11,
+            [
+                "World Data",
+                "Nations",
+                "Major Length",
+                "Secs/Nation",
+                "Nations/Sec",
+                "Minor Length",
+                "Secs/Nation",
+                "Nations/Sec",
+                "",
+                "Srsglass Version",
+                "Date Generated",
+            ],
+        )?;
+
+        worksheet.write_number(1, 12, total_population)?;
+        worksheet.write_number(2, 12, major_length)?;
+        worksheet.write_number(3, 12, major_length as f64 / total_population as f64)?;
+        worksheet.write_number(4, 12, total_population as f64 / major_length as f64)?;
+        worksheet.write_number(5, 12, minor_length)?;
+        worksheet.write_number(6, 12, minor_length as f64 / total_population as f64)?;
+        worksheet.write_number(7, 12, total_population as f64 / minor_length as f64)?;
+        worksheet.write_string(9, 12, env!("CARGO_PKG_VERSION"))?;
+
+        // set column width to fit date
+        worksheet.set_column_width(12, 10)?;
+
+        // set column widths to fit timestamp
+        worksheet.set_column_width(4, 10)?;
+        worksheet.set_column_width(5, 10)?;
+
+        worksheet.write_datetime_with_format(
+            10,
+            12,
+            &ExcelDateTime::from_timestamp(
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)?
+                    .as_secs()
+                    .try_into()?,
+            )?,
+            &Format::new().set_num_format("yyyy-mm-dd;@"),
+        )?;
+
+        let mut row_index = 1;
+
+        for region in regions {
+            let Region {
+                name: Some(name),
+                population: Some(population),
+                delegate_votes: Some(delegate_votes),
+                factbook: Some(mut factbook),
+                nations_before: Some(nations_before),
+                delegate_exec: Some(delegate_exec),
+                embassies,
+                ..
+            } = region
+            else {
+                continue;
+            };
+
+            let is_governorless = governorless.iter().any(|r| r == &name);
+            let is_passwordless = passwordless.iter().any(|r| r == &name);
+
+            let format = if is_governorless && is_passwordless {
+                Some(&green_fill)
+            } else if !is_governorless && delegate_exec && is_passwordless {
+                Some(&yellow_fill)
+            } else if !is_passwordless {
+                Some(&red_fill)
+            } else {
+                None
+            };
+
+            let link = format!(
+                "https://www.nationstates.net/region={}",
+                name.to_lowercase().replace(' ', "_")
+            );
+
+            if let Some(format) = format {
+                worksheet.write_string_with_format(row_index, 0, &name, format)?;
+                worksheet.write_url_with_format(row_index, 1, link.as_str(), format)?;
+            } else {
+                worksheet.write_string(row_index, 0, &name)?;
+                worksheet.write_url(row_index, 1, link.as_str())?;
+            }
+
+            worksheet.write_number(row_index, 2, population)?;
+
+            worksheet.write_number(row_index, 3, nations_before)?;
+
+            let progress = nations_before as f64 / total_population as f64;
+
+            let minor_duration = progress * minor_length as f64;
+            let minor_h = (minor_duration / 3600.0).floor() as u16;
+            let minor_m = ((minor_duration / 60.0) % 60.0).floor() as u8;
+            let minor_s = (minor_duration % 60.0).floor() as u8;
+            let minor_ms = (minor_duration.fract() * 1000.0).round().clamp(0.0, 999.0) as u16;
+
+            worksheet.write_datetime(
+                row_index,
+                4,
+                &ExcelDateTime::from_hms_milli(minor_h, minor_m, minor_s, minor_ms)?,
+            )?;
+
+            let major_duration = progress * major_length as f64;
+            let major_h = (major_duration / 3600.0).floor() as u16;
+            let major_m = ((major_duration / 60.0) % 60.0).floor() as u8;
+            let major_s = (major_duration % 60.0).floor() as u8;
+            let major_ms = (major_duration.fract() * 1000.0).round().clamp(0.0, 999.0) as u16;
+
+            worksheet.write_datetime(
+                row_index,
+                5,
+                &ExcelDateTime::from_hms_milli(major_h, major_m, major_s, major_ms)?,
+            )?;
+
+            worksheet.write_number(row_index, 6, delegate_votes)?;
+
+            if delegate_votes == 0 {
+                worksheet.write_number_with_format(row_index, 7, delegate_votes, &red_fill)?;
+            } else {
+                worksheet.write_number(row_index, 7, delegate_votes - 1)?;
+            }
+
+            // maximum length of cell contents in Excel is 32,767 characters
+            // https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
+            let mut embassy_list = embassies.join(",");
+            embassy_list.truncate(32767);
+            worksheet.write_string(row_index, 8, embassy_list)?;
+
+            factbook.truncate(32767);
+            worksheet.write_string(row_index, 9, factbook)?;
+
+            row_index += 1;
+        }
+
+        workbook.save(output_file)?;
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,8 +243,7 @@ impl Dump {
         timestamp_precision: i32,
     ) -> Result<()> {
         let Dump {
-            dump_date: _dump_date, // Dump date is only used in the filename, which comes in from
-            // on high, so we can ignore it here.
+            dump_date,
             regions,
             governorless,
             passwordless,
@@ -320,6 +319,7 @@ impl Dump {
                 "",
                 "Srsglass Version",
                 "Date Generated",
+                "Dump Date",
             ],
         )?;
 
@@ -349,6 +349,13 @@ impl Dump {
                     .try_into()?,
             )?,
             &Format::new().set_num_format("yyyy-mm-dd;@"),
+        )?;
+        
+        worksheet.write_datetime_with_format(
+            11,
+            12,
+            &ExcelDateTime::parse_from_str(&dump_date.to_string())?,
+            &Format::new().set_num_format("yyyy-mm-dd"),
         )?;
 
         let mut row_index = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ impl Dump {
             )?,
             &Format::new().set_num_format("yyyy-mm-dd;@"),
         )?;
-        
+
         worksheet.write_datetime_with_format(
             11,
             12,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,24 +53,24 @@ impl Client {
     }
 
     /// Get the date NS will list this dump as in the archive.
-    fn compute_dump_date(&self, regions: &[Region]) -> Result<NaiveDate> { 
+    fn compute_dump_date(&self, regions: &[Region]) -> Result<NaiveDate> {
         // Extract first updating region
-        let Some(first_region) = regions.iter().min_by_key(|region| region.last_major) else { 
+        let Some(first_region) = regions.iter().min_by_key(|region| region.last_major) else {
             return Err(anyhow!("Regions not populated!"));
         };
 
         // Extract datetime of that regions last major update
-        let Some(first_update) = first_region.last_major else { 
+        let Some(first_update) = first_region.last_major else {
             return Err(anyhow!("Last update not present!"));
         };
 
-        let Some(datetime) = chrono::DateTime::from_timestamp(first_update, 0) else { 
+        let Some(datetime) = chrono::DateTime::from_timestamp(first_update, 0) else {
             return Err(anyhow!("Invalid date!"));
         };
 
         // Rebase the timestamp in EST
         let datetime = datetime.with_timezone(&Eastern);
-        let Some(datetime) = datetime.checked_sub_days(Days::new(1)) else { 
+        let Some(datetime) = datetime.checked_sub_days(Days::new(1)) else {
             return Err(anyhow!("Could not roll back one day!"));
         };
 
@@ -98,7 +98,7 @@ impl Client {
         let goverorless = self.get_governorless_regions()?;
         let passwordless = self.get_passwordless_regions()?;
 
-        let dump_date = self.compute_dump_date(&regions)?; 
+        let dump_date = self.compute_dump_date(&regions)?;
 
         Ok(Dump {
             dump_date,
@@ -244,7 +244,7 @@ impl Dump {
     ) -> Result<()> {
         let Dump {
             dump_date: _dump_date, // Dump date is only used in the filename, which comes in from
-                                   // on high, so we can ignore it here.
+            // on high, so we can ignore it here.
             regions,
             governorless,
             passwordless,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,9 @@ struct Cli {
     user_nation: String,
 
     /// Name of the output file
-    #[arg(short, long, default_value = "srsglass.xlsx")]
-    outfile: String,
+    // #[arg(short, long, default_value = "srsglass.xlsx")]
+    #[arg(short, long)]
+    outfile: Option<String>,
 
     /// Length of major update, in seconds
     #[arg(long = "major", default_value_t = 5350)]
@@ -41,6 +42,16 @@ fn main() -> Result<()> {
 
     println!("Running srsglass with user nation {}", args.user_nation);
 
+    let outfile = match args.outfile { 
+        Some(filename) => filename, 
+        None => { 
+            let local = chrono::Local::now().date_naive();
+            let filename: String = format!("spyglass{}.xlsx", local);
+
+            filename
+        }
+    };
+
     let user_agent = format!(
         "{}/{} (by:Esfalsa, usedBy:{})",
         env!("CARGO_PKG_NAME"),
@@ -60,16 +71,16 @@ fn main() -> Result<()> {
         client.get_dump()?
     };
 
-    println!("Saving timesheet");
+    println!("Saving timesheet to {outfile}");
 
     dump.to_excel(
-        &args.outfile,
+        &outfile,
         args.major_length,
         args.minor_length,
         args.precision,
     )?;
 
-    println!("Saved timesheet to {}", args.outfile);
+    println!("Saved timesheet to {}", outfile);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,9 +68,9 @@ fn main() -> Result<()> {
     println!("Saving timesheet");
 
     // Use dump's date to dynamically create the filename if none is specified
-    let outfile = match args.outfile { 
-        Some(filepath) => filepath, 
-        None => format!("spyglass{}.xlsx", dump.dump_date)
+    let outfile = match args.outfile {
+        Some(filepath) => filepath,
+        None => format!("spyglass{}.xlsx", dump.dump_date),
     };
 
     dump.to_excel(

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,8 @@ struct Cli {
     user_nation: String,
 
     /// Name of the output file
-    // #[arg(short, long, default_value = "srsglass.xlsx")]
-    #[arg(short, long)]
-    outfile: Option<String>,
+    #[arg(short, long, default_value = "srsglass.xlsx")]
+    outfile: String,
 
     /// Length of major update, in seconds
     #[arg(long = "major", default_value_t = 5350)]
@@ -42,16 +41,6 @@ fn main() -> Result<()> {
 
     println!("Running srsglass with user nation {}", args.user_nation);
 
-    let outfile = match args.outfile { 
-        Some(filename) => filename, 
-        None => { 
-            let local = chrono::Local::now().date_naive();
-            let filename: String = format!("spyglass{}.xlsx", local);
-
-            filename
-        }
-    };
-
     let user_agent = format!(
         "{}/{} (by:Esfalsa, usedBy:{})",
         env!("CARGO_PKG_NAME"),
@@ -71,16 +60,16 @@ fn main() -> Result<()> {
         client.get_dump()?
     };
 
-    println!("Saving timesheet to {outfile}");
+    println!("Saving timesheet");
 
     dump.to_excel(
-        &outfile,
+        &args.outfile,
         args.major_length,
         args.minor_length,
         args.precision,
     )?;
 
-    println!("Saved timesheet to {}", outfile);
+    println!("Saved timesheet to {}", args.outfile);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,13 @@ struct Cli {
     user_nation: String,
 
     /// Name of the output file
-    #[arg(short, long, default_value = "srsglass.xlsx")]
-    outfile: String,
+    #[arg(short, long)]
+    outfile: Option<String>,
+
+    // TODO
+    /// Overwrite output file?
+    // #[arg(short, long, default_value_t = false)]
+    // overwrite: bool,
 
     /// Length of major update, in seconds
     #[arg(long = "major", default_value_t = 5350)]
@@ -62,14 +67,20 @@ fn main() -> Result<()> {
 
     println!("Saving timesheet");
 
+    // Use dump's date to dynamically create the filename if none is specified
+    let outfile = match args.outfile { 
+        Some(filepath) => filepath, 
+        None => format!("spyglass{}.xlsx", dump.dump_date)
+    };
+
     dump.to_excel(
-        &args.outfile,
+        &outfile,
         args.major_length,
         args.minor_length,
         args.precision,
     )?;
 
-    println!("Saved timesheet to {}", args.outfile);
+    println!("Saved timesheet to {}", outfile);
 
     Ok(())
 }


### PR DESCRIPTION
Addresses https://github.com/esfalsa/srsglass/issues/6 and https://github.com/esfalsa/srsglass/issues/7 by encoding the NS-recognized dump-date into the filename (spyglassYYYY-MM-DD.xslx) and into a new field in the sheet (Dump Date). 
Bumps version number from 0.1.0 to 0.2.0 to signal new field in sheet